### PR TITLE
Correctly quote commandline args

### DIFF
--- a/pd-wrapper.sh
+++ b/pd-wrapper.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-padsp -n "Pure Data (Flatpak)" pd-l2ork -oss $@
+padsp -n "Pure Data (Flatpak)" pd-l2ork -oss "$@"


### PR DESCRIPTION
This fixes an issue when opening a path that contains spaces.