### PR TITLE
Added LADSPA plugin support

### DIFF
--- a/net.purrdata.PurrData.yml
+++ b/net.purrdata.PurrData.yml
@@ -12,8 +12,19 @@ finish-args: [
     # Filesystem access (pd doesn't yet work with portals)
     '--filesystem=host',
     # MIDI access (Flatpak doesn't yet support exposing only MIDI devices)
-    '--device=all'
+    '--device=all',
+    # Linux Audio plugins
+    '--env=LADSPA_PATH=/app/extensions/LadspaPlugins/ladspa'
 ]
+add-extensions:
+  org.freedesktop.LinuxAudio.LadspaPlugins:
+    directory: extensions/LadspaPlugins
+    version: '19.08'
+    add-ld-path: lib
+    merge-dirs: ladspa
+    subdirectories: true
+    no-autodownload": true
+
 modules:
 - "shared-modules/lua5.3/lua-5.3.5.json"
 - name: purr-data
@@ -105,6 +116,8 @@ modules:
   - install -m 644 packages/linux_make/pd-l2ork.xml /app/share/mime/packages/net.purrdata.PurrData.xml
   # Default settings (mostly needed to set up the PD library search paths).
   - install -m 644 default.settings /app/lib/pd-l2ork
+  # Audio Plugins
+  - install -d /app/extensions/LadspaPlugins
   sources:
   - type: git
     url: https://github.com/agraef/purr-data/


### PR DESCRIPTION
We have LADSPA plugins on Flathub now.

This add support for the LADSPA plugins.

To test this:
- Install TAP from flathub `flathub install org.freedesktop.LinuxAudio.LadspaPlugins.TAP`
- download the patch at the bottom of this page: https://guitarextended.wordpress.com/2014/01/05/using-ladspa-plugins-within-pure-data/
- Start PurrData (with this PR applied) and load the patch above.

If the plugins are missing there is an error that it can't find the plugin. Otherwise the console witll show 
`plugin~: "TAP Rotary Speaker"`

