### PR TITLE
Update metainfo.xml file

### DIFF
--- a/net.purrdata.PurrData.metainfo.xml
+++ b/net.purrdata.PurrData.metainfo.xml
@@ -53,6 +53,8 @@
   <url type="bugtracker">https://git.purrdata.net/jwilkes/purr-data/issues</url>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.12.0" date="2020-07-17" />
+    <release version="2.11.0" date="2020-05-31" />
     <release version="2.10.1" date="2020-03-11" />
     <release version="2.10.0" date="2019-10-02" />
   </releases>


### PR DESCRIPTION
The version in Flathub was still showing as 2.10.1 and this is why.