### PR TITLE
Enable Pipewire/JACK backend

### DIFF
--- a/net.purrdata.PurrData.metainfo.xml
+++ b/net.purrdata.PurrData.metainfo.xml
@@ -12,17 +12,6 @@
       user interface.
     </p>
     <p>
-        IMPORTANT: Running Purr Data under Flatpak is experimental.
-        The following are known limitations.
-    </p>
-    <ul>
-      <li>Realtime priority cannot be used.</li>
-      <li>JACK audio backend cannot be used.</li>
-    </ul>
-    <p>
-      Packages from https://www.purrdata.net/ do not have these limitations.
-    </p>
-    <p>
       Pure Data is an open source visual programming environment that runs on
       anything from personal computers to embedded devices (ie Raspberry Pi)
       and smartphones (via libpd, DroidParty (Android), and PdParty (iOS).

--- a/net.purrdata.PurrData.yml
+++ b/net.purrdata.PurrData.yml
@@ -10,8 +10,10 @@ finish-args:
 - --socket=x11
 - --socket=wayland
 - --device=dri
-# Audio access
+# Audio
 - --socket=pulseaudio
+- --system-talk-name=org.freedesktop.RealtimeKit1
+- --filesystem=xdg-run/pipewire-0
 # Filesystem access (pd doesn't yet work with portals)
 - --filesystem=host
 # MIDI access (Flatpak doesn't yet support exposing only MIDI devices)
@@ -29,13 +31,15 @@ add-extensions:
 
 modules:
 - shared-modules/lua5.3/lua-5.3.5.json
+# We expect to run against pipewire-jack, but we build with regular JACK libraries.
+- shared-modules/linux-audio/jack2.json
 # (optional) For fluidsynth
 - shared-modules/linux-audio/ladspa.json
 - fluidsynth.json
 - name: purr-data
   buildsystem: autotools
   subdir: pd/src
-  config-opts: [--disable-portaudio, --enable-alsa, --disable-oss, --disable-jack]
+  config-opts: [--disable-portaudio, --enable-alsa, --disable-oss, --enable-jack]
   sources:
   - type: git
     url: https://github.com/agraef/purr-data/


### PR DESCRIPTION
This is ready for early testing, see:
https://blogs.gnome.org/uraeus/2020/09/04/pipewire-late-summer-update-2020/
and: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1001#note_402468357