### PR TITLE
Update metainfo.xml with 2.17 release

### DIFF
--- a/net.purrdata.PurrData.metainfo.xml
+++ b/net.purrdata.PurrData.metainfo.xml
@@ -43,6 +43,7 @@
   <url type="bugtracker">https://git.purrdata.net/jwilkes/purr-data/issues</url>
   <content_rating type="oars-1.1" />
   <releases>
+    <release version="2.17.0" date="2021-04-17" />
     <release version="2.14.0" date="2020-09-12" />
     <release version="2.13.0" date="2020-08-01" />
     <release version="2.12.0" date="2020-07-17" />


### PR DESCRIPTION
https://flathub.org/apps/details/net.purrdata.PurrData still shows the
release as 2.14.0.