### PR TITLE
Slight update to plugin path

### DIFF
--- a/net.purrdata.PurrData.yml
+++ b/net.purrdata.PurrData.yml
@@ -19,7 +19,7 @@ finish-args:
 # MIDI access (Flatpak doesn't yet support exposing only MIDI devices)
 - --device=all
 # Linux Audio plugins
-- --env=LADSPA_PATH=/app/extensions/Plugins/ladspa:/app/extensions/LadspaPlugins/ladspa
+- --env=LADSPA_PATH=/app/extensions/Plugins/ladspa:/app/lib/ladspa
 add-extensions:
   org.freedesktop.LinuxAudio.Plugins:
     directory: extensions/Plugins


### PR DESCRIPTION
One of the directory no longer exist, and `/app/lib/ladspa` is recommended for "system" installed