### PR TITLE
Only track stable versions

### DIFF
--- a/net.purrdata.PurrData.metainfo.xml
+++ b/net.purrdata.PurrData.metainfo.xml
@@ -43,7 +43,6 @@
   <url type="bugtracker">https://git.purrdata.net/jwilkes/purr-data/issues</url>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="2.19.0" date="2023-01-18"/>
     <release version="2.18.1" date="2023-01-17"/>
     <release version="2.17.0.1" date="2021-11-17"/>
     <release version="2.17.0" date="2021-04-17"/>

--- a/net.purrdata.PurrData.yml
+++ b/net.purrdata.PurrData.yml
@@ -41,8 +41,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/agraef/purr-data/
-        tag: 2.19.0
-        commit: 51e6d460c94cfa196f695f6688c927b7e2b501f7
+        tag: 2.18.1
+        commit: e1770339836b730bb213a48af685914ac921e27f
         x-checker-data:
       # Auto updates using https://github.com/flathub/flatpak-external-data-checker
           type: git
@@ -91,8 +91,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/agraef/purr-data/
-        tag: 2.19.0
-        commit: 51e6d460c94cfa196f695f6688c927b7e2b501f7
+        tag: 2.18.1
+        commit: e1770339836b730bb213a48af685914ac921e27f
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
@@ -105,8 +105,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/agraef/purr-data/
-        tag: 2.19.0
-        commit: 51e6d460c94cfa196f695f6688c927b7e2b501f7
+        tag: 2.18.1
+        commit: e1770339836b730bb213a48af685914ac921e27f
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
@@ -139,8 +139,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/agraef/purr-data/
-        tag: 2.19.0
-        commit: 51e6d460c94cfa196f695f6688c927b7e2b501f7
+        tag: 2.18.1
+        commit: e1770339836b730bb213a48af685914ac921e27f
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$

--- a/net.purrdata.PurrData.yml
+++ b/net.purrdata.PurrData.yml
@@ -29,6 +29,13 @@ add-extensions:
     subdirectories: true
     no-autodownload: true
 
+cleanup:
+  - /include/*
+  - /lib/pd-l2ork/Makefile.am
+  - /lib/pd-l2ork/README.txt
+  - /lib/pd-l2ork/bin/todo.txt
+  - /lib/pd-l2ork/bin/nw/credits.html
+
 modules:
   - shared-modules/lua5.3/lua-5.3.5.json
 # (optional) For fluidsynth
@@ -44,9 +51,10 @@ modules:
         tag: 2.18.1
         commit: e1770339836b730bb213a48af685914ac921e27f
         x-checker-data:
-      # Auto updates using https://github.com/flathub/flatpak-external-data-checker
-          type: git
-          tag-pattern: ^([\d.]+)$
+          type: json
+          url: https://api.github.com/repos/agraef/purr-data/releases/latest
+          tag-query: .tag_name
+          version-query: $tag
           is-main-source: true
       - type: patch
         path: patch/gnu-make-parallel.patch
@@ -94,8 +102,10 @@ modules:
         tag: 2.18.1
         commit: e1770339836b730bb213a48af685914ac921e27f
         x-checker-data:
-          type: git
-          tag-pattern: ^([\d.]+)$
+          type: json
+          url: https://api.github.com/repos/agraef/purr-data/releases/latest
+          tag-query: .tag_name
+          version-query: $tag
 
   - name: pd-abstractions
     buildsystem: simple
@@ -108,8 +118,10 @@ modules:
         tag: 2.18.1
         commit: e1770339836b730bb213a48af685914ac921e27f
         x-checker-data:
-          type: git
-          tag-pattern: ^([\d.]+)$
+          type: json
+          url: https://api.github.com/repos/agraef/purr-data/releases/latest
+          tag-query: .tag_name
+          version-query: $tag
 
   - name: purr-data-integration
     buildsystem: simple
@@ -142,8 +154,10 @@ modules:
         tag: 2.18.1
         commit: e1770339836b730bb213a48af685914ac921e27f
         x-checker-data:
-          type: git
-          tag-pattern: ^([\d.]+)$
+          type: json
+          url: https://api.github.com/repos/agraef/purr-data/releases/latest
+          tag-query: .tag_name
+          version-query: $tag
       - type: file
     # Using an binary x86_64 build of nw.js makes me sad. There are ARM packages
     # available from the nw.js website. For other platforms, it's difficult but
@@ -160,10 +174,3 @@ modules:
         path: default.settings
       - type: patch
         path: patch/flatpak-alsa-pulse.patch
-
-cleanup:
-  - /include/*
-  - /lib/pd-l2ork/Makefile.am
-  - /lib/pd-l2ork/README.txt
-  - /lib/pd-l2ork/bin/todo.txt
-  - /lib/pd-l2ork/bin/nw/credits.html


### PR DESCRIPTION
2.19.0 is a snapshot. Don't use it

use f-e-d-c github release traking.